### PR TITLE
redis deplyment: enable FLUSHDB command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ $ helm install redis-single --namespace redis \
   --set usePassword=false \
   --set cluster.enabled=false \
   --set master.persistence.enabled=false \
+  --set master.disableCommands={"FLUSHALL"} \
     bitnami/redis
 ```
 
+**Note**: The parameter `--set master.disableCommands={"FLUSHALL"}` enables the [FLUSHDB](https://redis.io/commands/flushdb) command in Redis, which allows to delete everything in a database. This is needed for the `Flush Redis Data` action in this example, but should be used carefully. To disbale the FLUSHDB command, just remove the line `--set master.disableCommands={"FLUSHALL"} \`
 
 ### Configuration Check/Change
 


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>


The helm command to deploy redis for this example, doesn't enable the FLUSHDB command in Redis.
This causes the `Flush Redis Data ` to fail.

This PR adds the parameter to helm command to enable FLUSHDB command with a warning note.